### PR TITLE
Fix "Rubberband:50: bad argument #1 to 'pointToObjectSpace' (Vector3 expected, got CFrame)"

### DIFF
--- a/TransformDragger.rbxmx
+++ b/TransformDragger.rbxmx
@@ -6645,10 +6645,11 @@ local function findPartsInSelection(startPos, endPos)
 			else
 				pos = v:GetModelCFrame().p
 			end
-			isLocked = false
 		elseif v:IsA("Tool") then
-			pos =  findFirstCFrame(v)
-			isLocked = false
+			pos = findFirstCFrame(v)
+			if pos then
+				pos = pos.p
+			end
 		end
 		
 		if pos then


### PR DESCRIPTION
There was a minor, but pretty severe problem with findPartsInSelection.
If there was a Tool in the Workspace with a Handle in it, no parts could be highlighted because findFirstCFrame wasn't being converted to a Vector3, and therefore pointToObjectSpace would fail.
