### PR TITLE
Update TerrainTools.rbxmx

### DIFF
--- a/TerrainTools.rbxmx
+++ b/TerrainTools.rbxmx
@@ -1132,6 +1132,12 @@ function FirstTimeSetUp()
 	updatePlaneLock()
 	updateSnapToGrid()
 	updateDynamicMaterial()
+	
+	-- Reset keyboard status on lost focus as key release may never come blocked by popups etc.
+	userInput.WindowFocusReleased:connect(function()
+		downKeys = {}
+	end)
+
 end
 
 


### PR DESCRIPTION
This is a fix for a bug CLISTUDIO-8780. When user triggers a shortcut which opens a popup the script plugins saves "down" state for ALT and SHIFT keys, but it never receives up state because the up goes to the popup. The fix is to reset keyboard state array when the focus is transferred to another window.
