### PR TITLE
Fix Convert To Smooth transition in smooth terrain tools

### DIFF
--- a/TerrainTools.rbxmx
+++ b/TerrainTools.rbxmx
@@ -29,7 +29,7 @@
 
 local Terrain = workspace:WaitForChild('Terrain', 86400) or workspace:WaitForChild('Terrain')
 while not Terrain.IsSmooth do
-	workspace.Terrain.Changed:wait()
+	Terrain.Changed:wait()
 end
 
 local on = false
@@ -1342,7 +1342,7 @@ return {
 
 local Terrain = workspace:WaitForChild('Terrain', 86400) or workspace:WaitForChild('Terrain')
 while not Terrain.IsSmooth do
-	workspace.Terrain.Changed:wait()
+	Terrain.Changed:wait()
 end
 
 local on = false


### PR DESCRIPTION
When ConvertToSmooth is called, we first unparent the Terrain object, fix
a few internal things, parent it back and then change IsSmooth to True.

Changed signal happens to fire for the first Parent change here, and
workspace.Terrain is nil at that point, which makes the script crash.

Since the actual Terrain object does not change, it just gets unparented
and reparented, just use the local version to fix this.
