### PR TITLE
CLISTUDIO-12326  Fixed error stream in output when selectedPart is nil

### DIFF
--- a/TransformDragger.rbxmx
+++ b/TransformDragger.rbxmx
@@ -1422,7 +1422,9 @@ function updatePart()
 		end
 	end
 	
-	updateChildAttachments(selectedPart, preActionSize, selectedPart.Size)
+	if (selectedPart) then
+		updateChildAttachments(selectedPart, preActionSize, selectedPart.Size)
+	end
 		
 	if allowAdornUpdate then
 		updateDragPart()


### PR DESCRIPTION
This commit fixes the error messages in the Transform dragger tool when rotating multiple parts by checking to see if selectedPart exists before using it.
https://jira.roblox.com/browse/CLISTUDIO-12326